### PR TITLE
添加Laravel Package Discovery,使其兼容最新版Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Jormin\\Geetest\\GeetestServiceProvider"
+            ],
+            "aliases": {
+                "Geetest": "Jormin\\Geetest\\Facades\\Geetest"
+            }
         }
     },
     "config": {


### PR DESCRIPTION
Laravel自v5.5开始,已经支持扩展包的自动发现,仅需要在composer.json中添加几行代码,即可优化扩展包的安装过程.